### PR TITLE
fix: add sanity check for currentOpaqueShopId

### DIFF
--- a/components/DummyData.js
+++ b/components/DummyData.js
@@ -38,7 +38,7 @@ function DummyData() {
       }
     }
 
-    if (currentOpaqueShopId.length > 0) {
+    if (currentOpaqueShopId && currentOpaqueShopId.length > 0) {
       decodeAndSetShopId(currentOpaqueShopId);
     }
   }, [currentOpaqueShopId]);


### PR DESCRIPTION
Impact: **major**
Type: **bug fix**

### Issue
I'm getting a white page because the variable `currentOpaqueShopId` is `null` in the first render and we are accessing to length.
Link: http://localhost:4080/dummy-data

### Solution
Add sanity check 

### Breaking changes
No as far I'm aware.

### Testing
Manual test